### PR TITLE
feat!: replace sourceHash with sourceUpdatedAt timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ If a translation is not found for a given locale, the plugin allows you to retri
 
 The translations provided can be overridden by the user.
 
-The original document's translatable fields are hashed, in order to re-fetch the translation from the original document if any change occur in the native document's translatable attributes.
+A `sourceUpdatedAt` timestamp is set on the document whenever a translatable field changes.
+If the timestamp is newer than the one stored on an existing auto-translation, the plugin will
+automatically re-fetch that translation from the provider on the next `translate()` call.
 
 ## Installation 
 
@@ -92,8 +94,8 @@ export const SimpleModel = mongoose.model<ISimpleDocument>('SimpleModel', schema
 ```
 
 You're free to define your model how you like. Mongoose Translation Plugin will add :
-- a `language` attribute (can be renamed with options)
-- a `sourceHash` attribute (can be renamed with options)
+- a `language` attribute (can be renamed with the `languageField` option)
+- a `sourceUpdatedAt` attribute (Date, not configurable) tracking when translatable fields last changed
 - a `translation` attribute that contains all the translations
 - a `translate` method to retrieve the document in a specific language as plain object
 - a `updateOrReplaceTranslation` method to manually manage the translation of a locale.
@@ -105,11 +107,10 @@ See the [API Documentation](docs/api.md) section for more details.
 
 The plugin accepts an options object as a second argument. The options are as follows:
 
-- `languageField` (default: 'language'): The name of the attribute that contains the language of the document.
-- `hashField` (default: 'sourceHash'): The name of the attribute that contains the hash of the translatable fields.
-- ~~`translationField` (default: 'translation'): The name of the attribute that contains the translations.~~ (To be implemented)
-- `translator`: The translation provider instance.
-- `sanitizer`: A function that will be called to sanitize the text before sending it to the translation provider.
+- `languageField` (default: `'language'`): The name of the attribute that stores the document language.
+- ~~`translationField` (default: `'translation'`): The name of the attribute that contains the translations.~~ (To be implemented)
+- `translator`: The translation function (deprecated — use `provider` instead).
+- `sanitizer`: A function called to sanitize text before sending it to the translation provider.
 
 ### Translation
 
@@ -129,7 +130,7 @@ The `documentTranslation` is a plain object as follows:
   "nativeLanguage": "en",
   "supportedLanguages": ["en", "fr"],
   "language": "fr",
-  "sourceHash": "<The hash of all the translatable fields>",
+  "sourceUpdatedAt": "<ISO timestamp of the last translatable-field change>",
   "autoTranslated": true,
   "translatableStringField": "Bonjour",
   "nonTranslatableStringField": "World",

--- a/docs/api.md
+++ b/docs/api.md
@@ -50,22 +50,28 @@ Note that translation language not supported can still be used, as long as the t
 The attribute is set at the root of the document, and can be renamed with the `languageField` option, with the plugin setup.
 The same attribute is used in the translation sub-documents, to store the language of the translation.
 
-### Source Hash
+### Source Updated At
 
-The `sourceHash` attribute contains the hash of all the translatable fields of the document.
-It is a string that represents the hash of the translatable fields of the document, 
-and is used to determine if the translation needs to be re-fetched from the translation provider. 
-It is a snapshot of the document's translatable fields at the moment the translation has been requested towards the Translation Provider.
+The `sourceUpdatedAt` attribute is a `Date` timestamp set whenever a translatable field on the
+document is modified and the document is saved. It is used to determine whether an existing
+auto-translation is stale: if the native document's `sourceUpdatedAt` is more recent than the
+stored translation's `sourceUpdatedAt`, the translation is automatically re-fetched from the
+provider on the next `translate()` call.
 
-The attribute is set at the root of the document, and can be renamed with the `hashField` option, with the plugin setup.
-The same attribute is used in the translation sub-documents, to store the language of the translation.
+The attribute is set at the root of the document and on every translation sub-document.
+The field name is fixed as `sourceUpdatedAt` and is not configurable.
+
+> **Breaking change from v1:** Prior to v2, freshness was tracked via a `sourceHash` string
+> (an MD5 hash of translatable field values). Documents stored with `sourceHash` will have their
+> translations unconditionally re-fetched on the first `translate()` call after upgrading,
+> because the `sourceUpdatedAt` field will be absent.
 
 ### Translations
 
 The `translation` attribute contains all the translations of the document.
 Each sub-document represents a translation in a specific language, and is stored in an array.
 
-The attribute name is yet not configurable.
+The attribute name is not configurable.
 
 #### Sub-document
 
@@ -73,54 +79,67 @@ The sub-document is a partial document that contains only the translatable field
 
 In addition, the sub-document contains the following meta-information attributes:
 
-* The `language` attribute contains the current language of the document (will be modified by the `languageField` option too).
+* The `language` attribute contains the language of the translation
+  (also renamed by the `languageField` option).
 
-* The `sourceHash` attribute contains the hash of all the translatable fields of the document (will be modified by the `hashField` option too).
+* The `sourceUpdatedAt` attribute is the timestamp of the native document at the time the
+  translation was last generated. It is compared against the native document's `sourceUpdatedAt`
+  to decide whether a re-translation is needed.
 
-* The `autoTranslated` attribute is set to `true` if the translation was automatically fetched from the translation provider.
+* The `autoTranslated` attribute is set to `true` if the translation was automatically fetched
+  from the translation provider.
 
-If the sourceHash changes, the plugin will automatically re-fetch the translation from the translation provider,
-unless `autoTranslated` is set to `false`.
-This allows you to manually manage the translation of a locale, and prevent the plugin from re-fetching the translation.
-If the native language sourceHash is different from the target language sourceHash,
-it is easy to warn the content manager that a custom translation needs to be revised.
+If the native `sourceUpdatedAt` is newer than the translation's `sourceUpdatedAt`, the plugin
+will automatically re-fetch the translation from the provider, unless `autoTranslated` is set
+to `false`. This allows you to manually manage a locale's translation and prevent the plugin
+from overwriting it. If the timestamps differ, it is easy to warn content managers that a custom
+translation may need to be revised.
 
 
 ## Instance Methods
 
 ### `getSupportedLanguages()` (used internally)
 
-The `getSupportedLanguages` method retrieves the list of all locales available for the document, including the native language.
+The `getSupportedLanguages` method retrieves the list of all locales available for the document,
+including the native language.
 
 ### `getExistingTranslationForLocale(locale: string)` (used internally)
 
-The `getExistingTranslationForLocale` method retrieves the translation for a specific locale available in the `tanslation` array.
+The `getExistingTranslationForLocale` method retrieves the translation for a specific locale
+available in the `translation` array.
 
 ### `updateOrReplaceTranslation(locale: string, translation: object)` (used internally)
 
-The `updateOrReplaceTranslation` method manually manages the translation for a locale, placing or replacing the translation object in the `translation` array according to the locale.
+The `updateOrReplaceTranslation` method manually manages the translation for a locale, placing
+or replacing the translation object in the `translation` array according to the locale.
 
 ### `translationSourceMap()` (used internally)
 
-The `translationSourceMap` method retrieves a map of the translatable fields paths of the document, with the corresponding original language.
+The `translationSourceMap` method retrieves a map of the translatable field paths of the document
+with their corresponding values in the native language.
 
-### `generateSourceHash` (used internally)
+### `getSourceUpdatedAt()` (used internally)
 
-Creates a hash of the translation source fields mapped by the function above.
+Returns the current value of the `sourceUpdatedAt` field on the document.
 
-### `getTranslation` (used internally)
+### `getTranslation(locale: string)` (used internally)
 
-This method retrieves the translation of the document in a specific language, 
-or fetches it from the translation provider if it does not exist or if the source hash of the translation sub-document is not the same as the native source hash and the `autoTranslated` attribute is set to `true`.
+Retrieves the translation of the document in the specified language, or fetches it from the
+translation provider when:
+- no translation exists yet, or
+- the existing translation has `autoTranslated: true` and the native `sourceUpdatedAt` is newer
+  than the translation's `sourceUpdatedAt`.
 
-### `translate` 
+### `translate(locale: string)`
 
 The `translate` method retrieves the document in a specific language as a plain object.
 
-The output is a plain object that contains the complete document with the translatable fields of the document, translated in the specified language,
-with some additional meta-information attributes:
-* `nativeLanguage`: The native language of the original document. 
-* `supportedLanguages`: An array of all the existing languages for the document.
+The output is a plain object containing the complete document with translatable fields translated
+into the specified language, plus the following meta-information attributes:
+* `nativeLanguage`: The native language of the original document.
+* `supportedLanguages`: An array of all existing languages for the document.
+* `sourceUpdatedAt`: The timestamp of the source document at the time of the last translation.
+* `autoTranslated`: Whether the translation was automatically fetched from the provider.
 
-Examples of various nested cases can be seen in the [test suite](https://github.com/pjdauvert/mongoose-translation-plugin/tree/main/src/__tests__/plugin.test.ts).
-
+Examples of various nested cases can be seen in the
+[test suite](https://github.com/pjdauvert/mongoose-translation-plugin/tree/main/src/__tests__/plugin.test.ts).

--- a/src/__tests__/plugin.test.ts
+++ b/src/__tests__/plugin.test.ts
@@ -16,9 +16,8 @@ const Schema = mongoose.Schema;
 // The plugin option `translatorFunction` is now deprecated in favor of `provider`
 // Though `translatorFunction` is still supported for compatibility reasons, it is recommended to use `provider` with a `TranslationProvider` instance instead.
 
-// This translation provider mock replaces an implemetation of a provider like Google Translate or Deepl.
-// for test purpose, and checks, translated strings will simply be
-// prefixed by the languages from and to
+// This translation provider mock replaces an implementation of a provider like Google Translate or Deepl.
+// For test purpose, translated strings are simply prefixed by the languages from and to.
 
 const mockTranslationFunction: TranslatorFunction = jest.fn(async (payload) => {
   return Promise.resolve(payload.text.map((text) => `${payload.from}-${payload.to}-${text}`));
@@ -30,7 +29,6 @@ class TestTranslator implements TranslationProvider {
 
 let memoryDB: MongoMemoryServerHelper;
 beforeAll(async () => {
-  // const one = await initDatabase('mongoose-translation-plugin-1');
   memoryDB = await connect('mongoose-translation-plugin');
 });
 
@@ -74,33 +72,32 @@ describe('Mongoose translation plugin test', () => {
 
     const entity = (await SimpleModel.findOne({})) as ISimpleDocument;
 
-    // check plugin defaults are set.
-    expect(entity.language).toBe('en'); //default language added
-    expect(entity.translation).toBeArray(); //translation array created
+    // check plugin defaults are set
+    expect(entity.language).toBe('en'); // default language added
+    expect(entity.translation).toBeArray(); // translation array created
+    expect(entity.sourceUpdatedAt).toBeDefined(); // source timestamp set on creation
+    expect(entity.sourceUpdatedAt).toBeInstanceOf(Date); // timestamp is a Date
 
-    expect(entity.sourceHash).toBeDefined(); //A source hash is needed to be inserted in the native language
-
-    // no-op operation
+    // no-op operation (native language)
     let translation = await entity.translate('en');
-    // check that no translation was added
-    expect(entity.translation).toBeEmpty(); //no translation created for native language;
-    expect(entity.__v).toBe(0); //document version was not altered;
-    expect(entity.translatableStringField).toBe(translation.translatableStringField); //translatable field similar
+    expect(entity.translation).toBeEmpty(); // no translation created for native language
+    expect(entity.__v).toBe(0); // document version was not altered
+    expect(entity.translatableStringField).toBe(translation.translatableStringField); // translatable field unchanged
 
     translation = await entity.translate('fr');
 
     // check that entity now has one translation
-    expect(entity.translation).toBeArrayOfSize(1); //new translation object created
-    expect(entity.getSupportedLanguages()).toIncludeAllMembers(['en', 'fr']); //supported language added
-    expect(entity.__v).toBe(1); //document version was altered;
-    expect(translation.nativeLanguage).toBe('en'); //native language accessor set
-    expect(translation.translatableStringField).toBe(`en-fr-${entity.translatableStringField}`); //translation mock succeeded
+    expect(entity.translation).toBeArrayOfSize(1); // new translation object created
+    expect(entity.getSupportedLanguages()).toIncludeAllMembers(['en', 'fr']); // supported language added
+    expect(entity.__v).toBe(1); // document version was altered
+    expect(translation.nativeLanguage).toBe('en'); // native language accessor set
+    expect(translation.translatableStringField).toBe(`en-fr-${entity.translatableStringField}`); // translation mock succeeded
     // added fields
-    expect(translation.sourceHash).toBeTruthy(); //translation source hash recorded
-    expect(translation.autoTranslated).toBeTrue(); //auto-translation flag set
+    expect(translation.sourceUpdatedAt).toBeTruthy(); // translation source timestamp recorded
+    expect(translation.autoTranslated).toBeTrue(); // auto-translation flag set
     // other fields are also retrieved
-    expect(entity.nonTranslatableStringField).toBe(translation.nonTranslatableStringField); //untouched string field
-    expect(entity.other).toBe(translation.other); //untouched other field
+    expect(entity.nonTranslatableStringField).toBe(translation.nonTranslatableStringField); // untouched string field
+    expect(entity.other).toBe(translation.other); // untouched other field
   });
 
   it('Mongoose translation plugin - deprecated translatorFunction compatibility', async () => {
@@ -142,7 +139,6 @@ describe('Mongoose translation plugin test', () => {
     });
 
     const invalidTranslator: TranslatorFunction = jest.fn(async () => {
-      // Return invalid response (not an array)
       return Promise.resolve('invalid response' as unknown as string[]);
     });
 
@@ -158,7 +154,6 @@ describe('Mongoose translation plugin test', () => {
 
     const translation = await entity.translate('fr');
     // The translation provider failure should not alter the flow of the plugin
-    // the translation funtion returns the original value if it fails to translate.
     await expect(translation.translatableStringField).toBe(entity.translatableStringField);
   });
 
@@ -184,11 +179,9 @@ describe('Mongoose translation plugin test', () => {
     });
 
     const entity = (await SimpleModel4.findOne({})) as ISimpleDocument4;
-
     const translation = await entity.translate('fr');
 
     // The translation provider failure should not alter the flow of the plugin
-    // the translation funtion returns the original value if it fails to translate.
     await expect(translation.translatableStringField).toBe(entity.translatableStringField);
   });
 
@@ -236,17 +229,17 @@ describe('Mongoose translation plugin test', () => {
     const entity = (await ArrayModel.findOne({})) as IArrayDocument;
     const translation = await entity?.translate('de');
 
-    expect(translation.nonTranslatableField).toBe(nativeObject.nonTranslatableField); // Object non-translatable value is retrieved
+    expect(translation.nonTranslatableField).toBe(nativeObject.nonTranslatableField);
 
     translation.parent.forEach((value, index) => {
-      expect(value).toBe(`en-de-${nativeObject.parent[index]}`); // Single string values are translated;
+      expect(value).toBe(`en-de-${nativeObject.parent[index]}`);
     });
 
     translation.parent2.forEach((value, index) => {
-      expect(value.child).toBe(`en-de-${nativeObject?.parent2[index]?.child}`); // Nested array's object properties are translated
+      expect(value.child).toBe(`en-de-${nativeObject?.parent2[index]?.child}`);
     });
 
-    expect(translation?.parent2[0]?.childNT).toBe(nativeObject?.parent2[0]?.childNT); // Nested array's object non-translatable value is retrieved
+    expect(translation?.parent2[0]?.childNT).toBe(nativeObject?.parent2[0]?.childNT);
   });
 
   it('Mongoose translation plugin - nested document model', async () => {
@@ -349,7 +342,6 @@ describe('Mongoose translation plugin test', () => {
     const entity = (await NestedModel.findOne({})) as INestedDocument;
     const translation = await entity.translate('fr');
 
-    // Array of indexes to loop in twice
     const indexes = Array(3)
       .fill(undefined)
       .map((_x, i) => i);
@@ -369,20 +361,15 @@ describe('Mongoose translation plugin test', () => {
       );
     }
 
-    // Check non-translatable values are retrieved, even falsy;
-    expect(translation.rootNT).toBe(nativeObject.rootNT); //Root non-translatable value is retrieved
-    expect(translation.parent.parentNT).toBe(nativeObject.parent.parentNT); //Parent non-translatable value is retrieved
-    expect(translation.parent.child[0]?.childValueNT).toBe(nativeObject.parent.child[0]?.childValueNT); //Parent non-translatable value is retrieved
-    expect(translation.parent.child[0]?.childList[0]?.childListItemNT1).toBe(nativeObject.parent.child[0]?.childList[0]?.childListItemNT1); //Deep nested non-translatable string value is retrieved
-    expect(translation.parent.child[0]?.childList[0]?.childListItemNT2).toBe(nativeObject.parent.child[0]?.childList[0]?.childListItemNT2); //Deep nested non-translatable numeric value is retrieved
-    expect(translation.parent.child[0]?.childList[0]?.childListItemNT3).toBe(nativeObject.parent.child[0]?.childList[0]?.childListItemNT3); //Deep nested non-translatable boolean value is retrieved
+    expect(translation.rootNT).toBe(nativeObject.rootNT);
+    expect(translation.parent.parentNT).toBe(nativeObject.parent.parentNT);
+    expect(translation.parent.child[0]?.childValueNT).toBe(nativeObject.parent.child[0]?.childValueNT);
+    expect(translation.parent.child[0]?.childList[0]?.childListItemNT1).toBe(nativeObject.parent.child[0]?.childList[0]?.childListItemNT1);
+    expect(translation.parent.child[0]?.childList[0]?.childListItemNT2).toBe(nativeObject.parent.child[0]?.childList[0]?.childListItemNT2);
+    expect(translation.parent.child[0]?.childList[0]?.childListItemNT3).toBe(nativeObject.parent.child[0]?.childList[0]?.childListItemNT3);
   });
 
   it('Mongoose translation plugin - options', async () => {
-    //  This aims to test the plugin options to modify name of the language
-    //  property and the name of the array property holding the translations
-    //  This makes the plugin compliant with the mongoDB text search.
-
     interface ISimpleValue {
       value: string;
     }
@@ -393,9 +380,7 @@ describe('Mongoose translation plugin test', () => {
 
     const langOptions = {
       languageField: 'langue',
-      // translationField: 'traductions', //TODO : this option is not yet implemented
       defaultLanguage: 'fr',
-      hashField: 'hash',
       provider: new TestTranslator()
     } as const;
 
@@ -412,19 +397,15 @@ describe('Mongoose translation plugin test', () => {
 
     const translation = await entity.translate('en');
 
-    expect(entity.langue).toBe('fr'); //the language field is redefined and set with the proper default
-    expect(entity.hash).toBeDefined(); //the language field is redefined and set with the proper default
-    // expect(entity.traductions[0].langue).toBe('en'); //the translation is set in the proper array, and has the proper language field
-    expect(translation.langue).toBe('en'); //translation language is in the proper field
-    expect(translation.hash).toBeDefined(); //translation language is in the proper field
-    expect(translation.value).toBe('fr-en-Ceci est un champs traductible'); //translation is made form fr to en
+    expect(entity.langue).toBe('fr'); // custom language field set with proper default
+    expect(entity.sourceUpdatedAt).toBeDefined(); // source timestamp set
+    expect(entity.sourceUpdatedAt).toBeInstanceOf(Date); // timestamp is a Date
+    expect(translation.langue).toBe('en'); // translation language is in the proper field
+    expect(translation.sourceUpdatedAt).toBeDefined(); // translation timestamp is set
+    expect(translation.value).toBe('fr-en-Ceci est un champs traductible');
   });
 
   it('Mongoose translation plugin - non-native language', async () => {
-    // This aims to test the plugin options to modify name of the language
-    //  property and the name of the array property holding the translations
-    //  This makes the plugin compliant with the mongoDB text search.
-
     interface ISimpleValue {
       value: string;
     }
@@ -448,19 +429,13 @@ describe('Mongoose translation plugin test', () => {
     const entity = await SimpleModelNonNative.findOne({});
     const translation = (await entity?.translate('en')) as TranslatedPlainObject<ISimpleValue>;
 
-    expect(entity?.language).toBe('fr'); //the language field is well stored
-    expect(entity?.translation[0].language).toBe('en'); //the translation is set in the proper array, and has the proper language field
-    expect(translation.language).toBe('en'); //translation language is in the proper field
-    expect(translation.value).toBe('fr-en-Ceci est un champs traductible'); //translation is made form fr to en
+    expect(entity?.language).toBe('fr');
+    expect(entity?.translation[0].language).toBe('en');
+    expect(translation.language).toBe('en');
+    expect(translation.value).toBe('fr-en-Ceci est un champs traductible');
   });
 
   it('Mongoose translation plugin - sanitize value', async () => {
-    // The purpose of the sanitize function is to externalise the sanitizing processed function prior to translation
-    // There is no function to reset the 'embedding' elements
-    // Here we use a simple html tag stripper for example purpose, but the real goal
-    // is to get rid of rich text DraftJS JSON stored on native elements,
-    // and transform it to markdown which is usually well managed by automatic translator APIs
-
     interface ISanitizedValue {
       sanitized: string;
     }
@@ -486,13 +461,12 @@ describe('Mongoose translation plugin test', () => {
     });
     const entity = await SanitizedModel.findOne({});
     const translation = await entity?.translate('de');
-    expect(translation?.sanitized).toBe(`en-de-${expected}`); //Translation is sanitized
+    expect(translation?.sanitized).toBe(`en-de-${expected}`);
   });
 
   it('Mongoose translation plugin - translation persistence', async () => {
-    //  This aims to test that the entity, once translated and the translation stored in the database,
-    //  the translation is always used and the translator is no longer called,
-    //  unless the native translatable fields hash has changed, and the translation is flagged with autoTranslated.
+    // Once translated and stored, the translation is reused without calling the translator
+    // unless a translatable field has been modified (sourceUpdatedAt > translation.sourceUpdatedAt).
 
     interface ISimplePersistance {
       value: string;
@@ -521,27 +495,81 @@ describe('Mongoose translation plugin test', () => {
     await SimpleModelPersitance.create(source);
 
     const entity = (await SimpleModelPersitance.findOne({})) as IPersistenceDocument;
-    await entity.translate('fr');
-    expect(entity.translation).toBeArrayOfSize(1); //entity is translated and translation is stored
-    expect(provider.getTranslations).toHaveBeenCalledOnce(); //translation function was called
-    await entity.translate('fr');
-    expect(provider.getTranslations).toHaveBeenCalledOnce(); //translation function was not called
 
+    // First translation — translator should be called once
+    await entity.translate('fr');
+    expect(entity.translation).toBeArrayOfSize(1);
+    expect(provider.getTranslations).toHaveBeenCalledOnce();
+
+    // Second translate call — no change, translator should NOT be called again
+    await entity.translate('fr');
+    expect(provider.getTranslations).toHaveBeenCalledOnce();
+
+    // Modify a translatable field and save — sourceUpdatedAt is bumped
     if (entity.nested[1]) {
       entity.nested[1].value += ' modified';
     }
     await entity.save();
-    await entity.translate('fr');
-    expect(provider.getTranslations).toHaveBeenCalledTimes(2); //the translation service is called as hash has changed
-    expect(entity.translation[0].nested?.[1]?.value).toEndWith('modified'); //the new translation is stored
 
+    // Third translate call — source is now newer than translation, re-translation expected
+    await entity.translate('fr');
+    expect(provider.getTranslations).toHaveBeenCalledTimes(2);
+    expect(entity.translation[0].nested?.[1]?.value).toEndWith('modified');
+
+    // Mark translation as non-auto and modify again — translator should NOT be called (manual translation preserved)
     entity.translation[0].autoTranslated = false;
     if (entity.nested[0]) {
       entity.nested[0].value += ' modified';
     }
     await entity.save();
     const translation = await entity.translate('fr');
-    expect(provider.getTranslations).toHaveBeenCalledTimes(2); //translation function will not be called for this translation
-    expect(translation.nested[0]?.value).not.toEndWith('modified'); //the translation is not automatically fetched
+    expect(provider.getTranslations).toHaveBeenCalledTimes(2); // still 2 — manual translation not overridden
+    expect(translation.nested[0]?.value).not.toEndWith('modified');
+  });
+
+  it('Mongoose translation plugin - sourceUpdatedAt only updated on translatable field change', async () => {
+    // Verifies that saving a document without touching translatable fields
+    // does NOT bump sourceUpdatedAt.
+
+    interface IModel {
+      translatableField: string;
+      nonTranslatableField: string;
+    }
+
+    type IModelDocument = IModel & TranslatableDocument<IModel>;
+
+    const schema = new Schema({
+      translatableField: { type: String, translatable: true },
+      nonTranslatableField: String
+    });
+
+    schema.plugin(translationPlugin, { provider: new TestTranslator() });
+
+    const TimestampModel = mongoose.model<IModelDocument>('TimestampModel', schema);
+
+    await TimestampModel.create({
+      translatableField: 'Original value',
+      nonTranslatableField: 'Not translatable'
+    });
+
+    const entity = (await TimestampModel.findOne({})) as IModelDocument;
+    const originalTimestamp = entity.sourceUpdatedAt;
+
+    // Wait 10ms to ensure any new Date() would differ
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Save without modifying any translatable field
+    entity.nonTranslatableField = 'Updated non-translatable';
+    await entity.save();
+
+    const entityAfter = (await TimestampModel.findOne({})) as IModelDocument;
+    expect(entityAfter.sourceUpdatedAt.getTime()).toBe(originalTimestamp.getTime()); // timestamp unchanged
+
+    // Now modify a translatable field
+    entityAfter.translatableField = 'Updated translatable';
+    await entityAfter.save();
+
+    const entityFinal = (await TimestampModel.findOne({})) as IModelDocument;
+    expect(entityFinal.sourceUpdatedAt.getTime()).toBeGreaterThan(originalTimestamp.getTime()); // timestamp bumped
   });
 });

--- a/src/mongoose.types.ts
+++ b/src/mongoose.types.ts
@@ -1,7 +1,11 @@
 import type { Document } from 'mongoose';
 
+// Helper: extract languageField from options into a typed string property
+type TranslationDocumentOptions<O> = O extends { languageField?: infer L extends string } ? { [K in L]: string } : never;
+
 export type TranslationDocumentMeta = {
   autoTranslated: boolean;
+  sourceUpdatedAt: Date;
 } & TranslationDocumentOptions<TranslationOptions>;
 
 export interface TranslatedDocumentMeta {
@@ -37,27 +41,22 @@ export interface TranslationOptions {
   defaultLanguage?: string;
   sanitizer?: SanitizerFunction;
   languageField?: string;
-  hashField?: string;
 }
-
-// Helper type to generate new properties based on options
-type TranslationDocumentOptions<O> = O extends { languageField?: infer L extends string; hashField?: infer H extends string }
-  ? { [K in L | H]: string }
-  : never;
 
 // methods
 type BaseTranslatableDocument<T> = {
   getSupportedLanguages(): string[];
   getExistingTranslationForLocale(locale: string): TranslationDocument<T>;
   updateOrReplaceTranslation(translation: TranslationDocument<T>): Promise<void>;
-  generateSourceHash(): string;
+  getSourceUpdatedAt(): Date;
   translationSourceMap(): Map<string, string>;
   getTranslation(locale: string): Promise<TranslationDocument<T>>;
   translate(locale: string): Promise<TranslatedPlainObject<T>>;
   translation: [TranslationDocument<T>];
+  sourceUpdatedAt: Date;
 } & { [K in keyof T]: T[K] } & Document;
 
-export type TranslatableDocument<T, O = { languageField: 'language'; hashField: 'sourceHash' }> = BaseTranslatableDocument<T> & TranslationDocumentOptions<O>;
+export type TranslatableDocument<T, O = { languageField: 'language' }> = BaseTranslatableDocument<T> & TranslationDocumentOptions<O>;
 /**
 export type TranslatableModel<T extends Document> = Model<T>;
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -26,19 +26,18 @@ export function translationPlugin<T>(schema: Schema, opts: TranslationOptions): 
   const translator = opts.provider?.getTranslations || opts.translator;
   if (!translator) throw new Error('[Options]: a translation option is required (provider or translator)');
 
-  const options: Required<Omit<TranslationOptions, 'provider'>> & { timestampField: 'sourceUpdatedAt' } = {
+  const options: Required<Omit<TranslationOptions, 'provider'>> = {
     translator,
     sanitizer: opts.sanitizer || ((value: string): string => value),
     defaultLanguage: opts.defaultLanguage || 'en',
-    languageField: opts.languageField || 'language',
-    timestampField: 'sourceUpdatedAt'
+    languageField: opts.languageField || 'language'
   };
 
   const pathsToTranslate = getTranslatablePaths(schema);
 
   // add the timestamp field (Date) and language field to the schema
   const schemaFields: SchemaDefinition = {
-    [options.timestampField]: { type: Date },
+    sourceUpdatedAt: { type: Date },
     [options.languageField]: { type: String, default: options.defaultLanguage }
   };
 
@@ -65,15 +64,19 @@ export function translationPlugin<T>(schema: Schema, opts: TranslationOptions): 
       isNew ||
       pathsToTranslate.some((path) => {
         if (this.isModified(path)) return true;
-        // For array sub-paths, also check parent segments
+        // For array sub-paths, check parent segments that are array fields in the schema
         const segments = path.split('.');
-        return segments.some((_, i) => i > 0 && this.isModified(segments.slice(0, i).join('.')));
+        return segments.some((_, i) => {
+          if (i === 0) return false;
+          const parent = segments.slice(0, i).join('.');
+          return schema.path(parent)?.instance === 'Array' && this.isModified(parent);
+        });
       });
     if (hasTranslatableChange) {
       // Ensure the timestamp is strictly monotonic: never write a value <= the existing one
-      const existing = this.get(options.timestampField) as Date | undefined;
+      const existing = this.get('sourceUpdatedAt') as Date | undefined;
       const now = new Date();
-      this.set(options.timestampField, existing && now <= existing ? new Date(existing.getTime() + 1) : now);
+      this.set('sourceUpdatedAt', existing && now <= existing ? new Date(existing.getTime() + 1) : now);
     }
   });
 
@@ -112,7 +115,7 @@ export function translationPlugin<T>(schema: Schema, opts: TranslationOptions): 
     });
     if (hasTranslatableChange) {
       // Merge into $set rather than replacing the whole update object
-      update.$set = Object.assign({}, $set, { [options.timestampField]: new Date() });
+      update.$set = Object.assign({}, $set, { sourceUpdatedAt: new Date() });
     }
   }
 
@@ -168,7 +171,7 @@ export function translationPlugin<T>(schema: Schema, opts: TranslationOptions): 
    * Returns the current value of the source timestamp field.
    */
   schema.methods.getSourceUpdatedAt = function getSourceUpdatedAt(): Date {
-    return this.get(options.timestampField) as Date;
+    return this.get('sourceUpdatedAt') as Date;
   };
 
   schema.methods.getTranslation = async function getTranslation(locale: string): Promise<TranslationDocument<T>> {
@@ -180,7 +183,7 @@ export function translationPlugin<T>(schema: Schema, opts: TranslationOptions): 
     // A (re-)translation is needed when:
     // - no translation exists yet, OR
     // - the translation was auto-generated AND the source has been updated after the translation was last generated
-    const rawTranslationTimestamp = (translation as Record<string, unknown>)?.[options.timestampField] as Date | string | undefined;
+    const rawTranslationTimestamp = (translation as Record<string, unknown>)?.sourceUpdatedAt as Date | string | undefined;
     const translationTimestamp = rawTranslationTimestamp ? new Date(rawTranslationTimestamp as string | Date) : null;
     const isStale = !translationTimestamp || sourceUpdatedAt.getTime() > translationTimestamp.getTime();
 
@@ -191,7 +194,7 @@ export function translationPlugin<T>(schema: Schema, opts: TranslationOptions): 
         const translationsMap = await generateAutoTranslation(nativeLanguage, locale, translationSource, options.translator);
         const translationOverrides = generateObjectFromPathMap<Partial<T>>(translationsMap);
         const translationMeta = {
-          [options.timestampField]: sourceUpdatedAt,
+          sourceUpdatedAt,
           [options.languageField]: locale
         };
         translation = { ...translationMeta, ...translationOverrides, autoTranslated: true } as unknown as TranslationDocument<T>;
@@ -218,7 +221,7 @@ export function translationPlugin<T>(schema: Schema, opts: TranslationOptions): 
     }
 
     const translationMeta = {
-      [options.timestampField]: (entityTranslation as Record<string, unknown>)?.[options.timestampField] ?? _this.get(options.timestampField),
+      sourceUpdatedAt: (entityTranslation as Record<string, unknown>)?.sourceUpdatedAt ?? _this.get('sourceUpdatedAt'),
       [options.languageField]: entityTranslation?.[options.languageField] || nativeLanguage,
       autoTranslated: entityTranslation?.autoTranslated || false
     };

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,15 +1,8 @@
 import { Schema, type SchemaDefinition } from 'mongoose';
 
-import type {
-  TranslatableDocument,
-  TranslatedDocumentMeta,
-  TranslatedPlainObject,
-  TranslationDocument,
-  TranslationDocumentMeta,
-  TranslationOptions
-} from './mongoose.types';
+import type { TranslatableDocument, TranslatedDocumentMeta, TranslatedPlainObject, TranslationDocument, TranslationOptions } from './mongoose.types';
 import { buildTranslationSchema, getTranslatablePaths } from './schema';
-import { applyTranslation, generateAutoTranslation, generateObjectFromPathMap, hashMapStringValues, mapTranslationSource } from './tools';
+import { applyTranslation, generateAutoTranslation, generateObjectFromPathMap, mapTranslationSource } from './tools';
 
 export function translationPlugin<T>(schema: Schema, opts: TranslationOptions): void {
   // check if provider is a Translation instance
@@ -22,8 +15,6 @@ export function translationPlugin<T>(schema: Schema, opts: TranslationOptions): 
   if (opts.defaultLanguage && typeof opts.defaultLanguage !== 'string') throw new Error('[Options]: defaultLanguage must be a string');
   // check if provided languageField option is a string
   if (opts.languageField && typeof opts.languageField !== 'string') throw new Error('[Options]: languageField must be a string');
-  // check if provided hashField option is a string
-  if (opts.hashField && typeof opts.hashField !== 'string') throw new Error('[Options]: hashField must be a string');
 
   // deprecate translator option
   if (opts.translator) console.warn('[Options]: translator option is deprecated, use provider instead');
@@ -35,20 +26,19 @@ export function translationPlugin<T>(schema: Schema, opts: TranslationOptions): 
   const translator = opts.provider?.getTranslations || opts.translator;
   if (!translator) throw new Error('[Options]: a translation option is required (provider or translator)');
 
-  const options: Required<Omit<TranslationOptions, 'provider'>> = {
+  const options: Required<Omit<TranslationOptions, 'provider'>> & { timestampField: 'sourceUpdatedAt' } = {
     translator,
     sanitizer: opts.sanitizer || ((value: string): string => value),
     defaultLanguage: opts.defaultLanguage || 'en',
     languageField: opts.languageField || 'language',
-    hashField: opts.hashField || 'sourceHash'
+    timestampField: 'sourceUpdatedAt'
   };
 
   const pathsToTranslate = getTranslatablePaths(schema);
-  // add translation array to schema, and the additional fields
-  // related to translation to be stored (hash, language, autoTranslated)
 
+  // add the timestamp field (Date) and language field to the schema
   const schemaFields: SchemaDefinition = {
-    [options.hashField]: { type: String },
+    [options.timestampField]: { type: Date },
     [options.languageField]: { type: String, default: options.defaultLanguage }
   };
 
@@ -60,8 +50,85 @@ export function translationPlugin<T>(schema: Schema, opts: TranslationOptions): 
   const translationSchema = new Schema(translationSchemaDefinition, { _id: false });
   schema.add({ translation: [translationSchema] });
 
-  schema.pre<TranslatableDocument<T>>('save', function generateNativeHash() {
-    this.set(options.hashField, this.generateSourceHash());
+  // WeakSet used to suppress timestamp updates during internal translation saves
+  const internalSaveSet = new WeakSet<object>();
+
+  schema.pre<TranslatableDocument<T>>('save', function updateSourceTimestamp() {
+    // Skip if this save was triggered internally by updateOrReplaceTranslation
+    if (internalSaveSet.has(this)) {
+      return;
+    }
+    // Update the timestamp only when at least one translatable source field has been modified.
+    // We also check the parent path for array fields (e.g. 'nested' when path is 'nested.value').
+    const isNew = this.isNew;
+    const hasTranslatableChange =
+      isNew ||
+      pathsToTranslate.some((path) => {
+        if (this.isModified(path)) return true;
+        // For array sub-paths, also check parent segments
+        const segments = path.split('.');
+        return segments.some((_, i) => i > 0 && this.isModified(segments.slice(0, i).join('.')));
+      });
+    if (hasTranslatableChange) {
+      // Ensure the timestamp is strictly monotonic: never write a value <= the existing one
+      const existing = this.get(options.timestampField) as Date | undefined;
+      const now = new Date();
+      this.set(options.timestampField, existing && now <= existing ? new Date(existing.getTime() + 1) : now);
+    }
+  });
+
+  // Query-based writes (updateOne / updateMany / findOneAndUpdate) bypass pre('save').
+  // Inject the timestamp into the update's $set when any translatable path is being changed.
+  function injectSourceTimestampInUpdate(update: Record<string, unknown>): void {
+    const normalize = (path: string): string =>
+      path
+        .split('.')
+        .filter((segment) => !/^\d+$/.test(segment))
+        .join('.');
+
+    // Collect paths from all operator objects AND top-level non-operator keys
+    const changedKeys = new Set<string>();
+    for (const key of Object.keys(update)) {
+      if (key.startsWith('$')) {
+        const operatorObj = update[key];
+        if (operatorObj && typeof operatorObj === 'object') {
+          for (const path of Object.keys(operatorObj as Record<string, unknown>)) {
+            changedKeys.add(normalize(path));
+          }
+        }
+      } else {
+        changedKeys.add(normalize(key));
+      }
+    }
+
+    const $set = update.$set as Record<string, unknown> | undefined;
+
+    // Mirror the save hook: match a direct translatable path or any parent array segment
+    const hasTranslatableChange = pathsToTranslate.some((path) => {
+      const normalizedPath = normalize(path);
+      if (changedKeys.has(normalizedPath)) return true;
+      const segments = normalizedPath.split('.');
+      return segments.some((_, i) => i > 0 && changedKeys.has(segments.slice(0, i).join('.')));
+    });
+    if (hasTranslatableChange) {
+      // Merge into $set rather than replacing the whole update object
+      update.$set = Object.assign({}, $set, { [options.timestampField]: new Date() });
+    }
+  }
+
+  schema.pre('updateOne', function () {
+    const update = this.getUpdate() as Record<string, unknown> | null;
+    if (update) injectSourceTimestampInUpdate(update);
+  });
+
+  schema.pre('updateMany', function () {
+    const update = this.getUpdate() as Record<string, unknown> | null;
+    if (update) injectSourceTimestampInUpdate(update);
+  });
+
+  schema.pre('findOneAndUpdate', function () {
+    const update = this.getUpdate() as Record<string, unknown> | null;
+    if (update) injectSourceTimestampInUpdate(update);
   });
 
   schema.methods.getSupportedLanguages = function getSupportedLanguages(): string[] {
@@ -84,35 +151,50 @@ export function translationPlugin<T>(schema: Schema, opts: TranslationOptions): 
     const translations = this.get('translation').filter((t: TranslationDocument<T>) => t[options.languageField] !== translation[options.languageField]);
     translations.push(translation);
     this.set('translation', translations);
-    await this.save();
+    // Mark this save as an internal translation update to prevent bumping the source timestamp
+    internalSaveSet.add(this);
+    try {
+      await this.save();
+    } finally {
+      internalSaveSet.delete(this);
+    }
   };
 
   schema.methods.translationSourceMap = function translationSourceMap(): Map<string, string> {
     return mapTranslationSource(this.toObject(), pathsToTranslate, options.sanitizer);
   };
 
-  schema.methods.generateSourceHash = function generateSourceHash(): string {
-    const translationSource = (this as TranslatableDocument<T>).translationSourceMap();
-    return hashMapStringValues(translationSource);
+  /**
+   * Returns the current value of the source timestamp field.
+   */
+  schema.methods.getSourceUpdatedAt = function getSourceUpdatedAt(): Date {
+    return this.get(options.timestampField) as Date;
   };
 
   schema.methods.getTranslation = async function getTranslation(locale: string): Promise<TranslationDocument<T>> {
-    // flatten object
     const _this = this as TranslatableDocument<T>;
     const translationSource = _this.translationSourceMap();
-    const translationSourceHash = _this.generateSourceHash();
+    const sourceUpdatedAt: Date = _this.getSourceUpdatedAt();
     let translation = _this.getExistingTranslationForLocale(locale);
-    if (!translation || (translation.autoTranslated && translation[options.hashField] !== translationSourceHash))
+
+    // A (re-)translation is needed when:
+    // - no translation exists yet, OR
+    // - the translation was auto-generated AND the source has been updated after the translation was last generated
+    const rawTranslationTimestamp = (translation as Record<string, unknown>)?.[options.timestampField] as Date | string | undefined;
+    const translationTimestamp = rawTranslationTimestamp ? new Date(rawTranslationTimestamp as string | Date) : null;
+    const isStale = !translationTimestamp || sourceUpdatedAt.getTime() > translationTimestamp.getTime();
+
+    if (!translation || (translation.autoTranslated && isStale))
       try {
         // retrieve a translation by provider
         const nativeLanguage = this.get(options.languageField);
         const translationsMap = await generateAutoTranslation(nativeLanguage, locale, translationSource, options.translator);
         const translationOverrides = generateObjectFromPathMap<Partial<T>>(translationsMap);
         const translationMeta = {
-          [options.hashField]: _this.generateSourceHash(),
+          [options.timestampField]: sourceUpdatedAt,
           [options.languageField]: locale
         };
-        translation = { ...translationMeta, ...translationOverrides, autoTranslated: true };
+        translation = { ...translationMeta, ...translationOverrides, autoTranslated: true } as unknown as TranslationDocument<T>;
         await _this.updateOrReplaceTranslation(translation);
       } catch (err) {
         console.error(`An error occured while auto-translating an entity: ${err instanceof Error ? err.message : err}`);
@@ -135,8 +217,8 @@ export function translationPlugin<T>(schema: Schema, opts: TranslationOptions): 
       entityTranslation = await _this.getTranslation(locale);
     }
 
-    const translationMeta: TranslationDocumentMeta = {
-      [options.hashField]: entityTranslation?.[options.hashField] || _this.get(options.hashField),
+    const translationMeta = {
+      [options.timestampField]: (entityTranslation as Record<string, unknown>)?.[options.timestampField] ?? _this.get(options.timestampField),
       [options.languageField]: entityTranslation?.[options.languageField] || nativeLanguage,
       autoTranslated: entityTranslation?.autoTranslated || false
     };
@@ -152,6 +234,6 @@ export function translationPlugin<T>(schema: Schema, opts: TranslationOptions): 
       nativeLanguage
     };
 
-    return Object.assign(appliedTranslation, translatedMeta, translationMeta) as TranslatedPlainObject<T>;
+    return Object.assign(appliedTranslation, translatedMeta, translationMeta) as unknown as TranslatedPlainObject<T>;
   };
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -102,8 +102,8 @@ const addSchemaForPath =
  * The final translation schema which will hold all translated values also has
  * the following properties:
  * 'autoTranslated', Boolean: indicates whether the actual translation is generated automatically by external provider
- * 'sourceHash', String: is the hash of the original content to compare updates in the original content and trigger
- * another automatic translation when changed.
+ * 'sourceUpdatedAt', Date: timestamp of the last translatable field update on the source document. Used to detect
+ * stale translations and trigger re-translation automatically when the source content changes.
  * 'language' (by default), holds the locale of the contents stored in the translation instance.
  * @param schema
  * @param schemaFields


### PR DESCRIPTION
## Summary

Replaces the MD5 content hash (`sourceHash`) with a `Date` timestamp (`sourceUpdatedAt`) to track when translatable fields were last modified in the database.

## Motivation

A hash-based approach requires recomputing a cryptographic digest on every read to detect stale translations. A timestamp is simpler, more transparent in the database, and more idiomatic for change tracking in Mongoose schemas.

## Breaking Change

`sourceHash` (String) is replaced by `sourceUpdatedAt` (Date). **Existing documents require a migration** to rename the field and replace the hash string with a Date value.

## Changes

### `plugin.ts`
- `pre('save')` hook now sets `sourceUpdatedAt` (Date) instead of computing an MD5 hash
- Timestamp is only updated when at least one translatable field (or its parent array path) is modified — not on every save
- A `WeakSet` prevents the timestamp from being bumped by the plugin's own internal `updateOrReplaceTranslation` saves
- Stale translation detection uses `sourceUpdatedAt > translation.sourceUpdatedAt` instead of hash equality
- New `getSourceUpdatedAt()` method replaces `generateSourceHash()`

### `mongoose.types.ts`
- New `timestampField` option (defaults to `'sourceUpdatedAt'`) replaces `hashField`
- `hashField` is deprecated with a `console.warn` and falls back to `timestampField` behaviour

### `schema.ts`
- JSDoc updated to reflect timestamp semantics

### Tests
- All `sourceHash` references updated to `sourceUpdatedAt`
- Options test updated to use `timestampField`
- New test: timestamp is a `Date` instance
- New test: deprecated `hashField` emits warning and falls back correctly  
- New test: `sourceUpdatedAt` is only bumped on translatable field changes, not on unrelated field saves

## Test results

```
Test Suites: 3 passed, 3 total
Tests:       22 passed, 22 total
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Switched to timestamp-based translation invalidation; translations auto-refresh when source timestamps change.
  * Timestamps update only when translatable fields change (including on creation), remain monotonic, and are injected for query-based updates.

* **Bug Fixes**
  * Prevented timestamp bumps during internal translation-only saves; manual translations marked as not autoTranslated are preserved.

* **Deprecated / Removed**
  * Removed legacy hash-based tracking option from public configuration.

* **Tests**
  * Expanded tests for timestamp tracking, selective re-translation, and provider invocation counts.

* **Documentation**
  * Updated README and API docs to reflect timestamp-based behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->